### PR TITLE
change support dependency mode

### DIFF
--- a/groupedadapter/build.gradle
+++ b/groupedadapter/build.gradle
@@ -28,9 +28,9 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-
-    compile 'com.android.support:recyclerview-v7:25.3.1'
+    //compileOnly
+    provided 'com.android.support:appcompat-v7:25.3.1'
+    provided 'com.android.support:recyclerview-v7:25.3.1'
 }
 
 //---------------------------------------------


### PR DESCRIPTION
If you use compile mode that version referenced by the app (the latest version 28.0.0) will cause conflicts when you refer to it. You need to manually add exclude, so it is better to change to compileOnly(provided).